### PR TITLE
Auto switch to Node Properties tab

### DIFF
--- a/app/src/pages/mapping_page/components/MainPanel/components/BaseNode.tsx
+++ b/app/src/pages/mapping_page/components/MainPanel/components/BaseNode.tsx
@@ -1,22 +1,32 @@
 import { cn } from '@/utils/cn';
 import React from 'react';
 
+import useMappingPage from '@/pages/mapping_page/state';
 import './styles.scss';
 
 export const BaseNode = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & { selected?: boolean }
->(({ className, selected, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      'base-node',
-      selected ? 'base-node--selected' : '',
-      'base-node--hover',
-      className,
-    )}
-    tabIndex={0}
-    {...props}
-  />
-));
+>(({ className, selected, ...props }, ref) => {
+  const setSelectedTab = useMappingPage(state => state.setSelectedTab);
+
+  const onClick = React.useCallback(() => {
+    setSelectedTab('properties');
+  }, [setSelectedTab]);
+
+  return (
+    <div
+      ref={ref}
+      onClick={onClick}
+      className={cn(
+        'base-node',
+        selected ? 'base-node--selected' : '',
+        'base-node--hover',
+        className,
+      )}
+      tabIndex={0}
+      {...props}
+    />
+  );
+});
 BaseNode.displayName = 'BaseNode';


### PR DESCRIPTION
Add an onClick handler to the base node that automatically opens the properties panel when a node is selected. 
Fixes #7