### PR TITLE
feature: added alert dialog if user tries to exit mappin withoit saving it

### DIFF
--- a/app/src/components/Chat/styles.scss
+++ b/app/src/components/Chat/styles.scss
@@ -1,7 +1,7 @@
 .chat {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: start;
   overflow-y: auto;
   height: 100%;
   flex-grow: 1;

--- a/app/src/pages/mapping_page/components/MainPanel/index.tsx
+++ b/app/src/pages/mapping_page/components/MainPanel/index.tsx
@@ -261,6 +261,7 @@ const MainPanel = ({ initialGraph }: MainPanelProps) => {
           source: fromNode.id,
           sourceHandle: fromHandle.id,
         });
+        setNewNode(null);
 
         if (event instanceof MouseEvent)
           openMenu({

--- a/app/src/pages/mapping_page/components/Navbar/index.tsx
+++ b/app/src/pages/mapping_page/components/Navbar/index.tsx
@@ -13,6 +13,7 @@ type NavbarProps = {
   mapping_uuid: string | undefined;
   name: string | undefined;
   isLoading: string | null;
+  triggerSaveAlert: () => void;
   onCompleteMapping: () => void;
 };
 
@@ -21,6 +22,7 @@ const Navbar = ({
   mapping_uuid,
   name,
   isLoading,
+  triggerSaveAlert,
   onCompleteMapping,
 }: NavbarProps) => {
   const navigation = useNavigate();
@@ -44,7 +46,8 @@ const Navbar = ({
           icon='arrow-left'
           minimal
           onClick={() => {
-            navigation(`/workspaces/${workspace_uuid}`);
+            if (isSaved) navigation(`/workspaces/${workspace_uuid}`);
+            else triggerSaveAlert();
           }}
         />
         <div style={{ width: 10 }} />

--- a/app/src/pages/mapping_page/components/SaveAlert/index.tsx
+++ b/app/src/pages/mapping_page/components/SaveAlert/index.tsx
@@ -1,0 +1,79 @@
+import {
+  XYEdgeType,
+  XYNodeTypes,
+} from '@/pages/mapping_page/components/MainPanel/types';
+import useMappingPage from '@/pages/mapping_page/state';
+import { Button, Dialog, DialogBody, DialogFooter } from '@blueprintjs/core';
+import { useEdges, useNodes } from '@xyflow/react';
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface SaveAlertProps {
+  onClose: () => void;
+  workspace_uuid: string | undefined;
+  mapping_uuid: string | undefined;
+  open: boolean;
+}
+
+const SaveAlert = (props: SaveAlertProps) => {
+  const navigate = useNavigate();
+
+  const mapping = useMappingPage(state => state.mapping);
+  const saveMapping = useMappingPage(state => state.saveMapping);
+
+  const nodes = useNodes<XYNodeTypes>();
+  const edges = useEdges<XYEdgeType>();
+
+  const onSave = useCallback(async () => {
+    if (!props.workspace_uuid || !props.mapping_uuid || !mapping) return;
+    await saveMapping(
+      props.workspace_uuid,
+      props.mapping_uuid,
+      mapping,
+      nodes,
+      edges,
+    );
+    navigate(`/workspaces/${props.workspace_uuid}`);
+  }, [
+    nodes,
+    edges,
+    mapping,
+    saveMapping,
+    navigate,
+    props.workspace_uuid,
+    props.mapping_uuid,
+  ]);
+
+  const onDiscard = useCallback(() => {
+    navigate(`/workspaces/${props.workspace_uuid}`);
+  }, [navigate, props.workspace_uuid]);
+
+  return (
+    <Dialog
+      title='Unsaved Changes'
+      isOpen={props.open}
+      onClose={props.onClose}
+      icon='warning-sign'
+      className='bp5-dark'
+    >
+      <DialogBody>
+        <p>There are unsaved changes. Do you want to save them?</p>
+      </DialogBody>
+      <DialogFooter
+        actions={
+          <>
+            <Button intent='primary' onClick={onSave}>
+              Save
+            </Button>
+            <Button intent='danger' onClick={onDiscard}>
+              Discard
+            </Button>
+            <Button onClick={props.onClose}>Cancel</Button>
+          </>
+        }
+      />
+    </Dialog>
+  );
+};
+
+export default SaveAlert;

--- a/main.py
+++ b/main.py
@@ -105,8 +105,7 @@ if __name__ == "__main__":
         window = webview.create_window(
             "RDFCraft",
             f"http://localhost:{port}",
-            width=800,
-            height=600,
+            min_size=(800, 600),
             resizable=True,
         )
         window.events.closing += on_closing

--- a/server/services/core/mapping_to_yarrrml_service.py
+++ b/server/services/core/mapping_to_yarrrml_service.py
@@ -111,6 +111,9 @@ class MappingToYARRRMLService(MappingToYARRRMLServiceProtocol):
                 }
 
             case SourceType.JSON:
+                # If iterator does not end with .[*] add it
+                if not source.extra["json_path"].endswith(".[*]"):
+                    source.extra["json_path"] += ".[*]"
                 source_dict["data"] = {
                     "access": str(source_path.absolute()),
                     "referenceFormulation": "jsonpath",


### PR DESCRIPTION

This pull request includes several changes to improve the user experience and functionality of the mapping page, along with some minor adjustments in other parts of the codebase. The most important changes include the addition of a save alert dialog, modifications to the navigation logic to handle unsaved changes, and a few minor updates to styles and other components.

### Save Alert Dialog:

* [`app/src/pages/mapping_page/components/SaveAlert/index.tsx`](diffhunk://#diff-d1cb3d4dda67d0a44498346e156f988688fd79c4afc556e7f755df4d97900c06R1-R79): Added a new `SaveAlert` component to prompt users to save or discard changes when navigating away from the mapping page.
* [`app/src/pages/mapping_page/index.tsx`](diffhunk://#diff-5d9c4fcc6b949d4bc9a46d0c1c8fb52a28e7c1c739ddbe446cd80504c04a57a5R3): Integrated the `SaveAlert` component and added logic to trigger it when there are unsaved changes. [[1]](diffhunk://#diff-5d9c4fcc6b949d4bc9a46d0c1c8fb52a28e7c1c739ddbe446cd80504c04a57a5R3) [[2]](diffhunk://#diff-5d9c4fcc6b949d4bc9a46d0c1c8fb52a28e7c1c739ddbe446cd80504c04a57a5L13-R14) [[3]](diffhunk://#diff-5d9c4fcc6b949d4bc9a46d0c1c8fb52a28e7c1c739ddbe446cd80504c04a57a5L48-R51) [[4]](diffhunk://#diff-5d9c4fcc6b949d4bc9a46d0c1c8fb52a28e7c1c739ddbe446cd80504c04a57a5R114-R121) [[5]](diffhunk://#diff-5d9c4fcc6b949d4bc9a46d0c1c8fb52a28e7c1c739ddbe446cd80504c04a57a5R159-R164) [[6]](diffhunk://#diff-5d9c4fcc6b949d4bc9a46d0c1c8fb52a28e7c1c739ddbe446cd80504c04a57a5R178)

### Navigation Logic:

* [`app/src/pages/mapping_page/components/Navbar/index.tsx`](diffhunk://#diff-eca5145ea0bff03f347902e0ae79e4817fa1af9e1a034663115029462429ecc3R16): Updated the `Navbar` component to include a `triggerSaveAlert` prop and modified the navigation logic to show the save alert if there are unsaved changes. [[1]](diffhunk://#diff-eca5145ea0bff03f347902e0ae79e4817fa1af9e1a034663115029462429ecc3R16) [[2]](diffhunk://#diff-eca5145ea0bff03f347902e0ae79e4817fa1af9e1a034663115029462429ecc3R25) [[3]](diffhunk://#diff-eca5145ea0bff03f347902e0ae79e4817fa1af9e1a034663115029462429ecc3L47-R50)

### Minor Updates:

* [`app/src/components/Chat/styles.scss`](diffhunk://#diff-cbe96ee4ba252c6510059600e326df1230c0674a1709c82cce2d1356eaa0b8cdL4-R4): Changed the `justify-content` property of the `.chat` class from `space-between` to `start`.
* [`app/src/pages/mapping_page/components/MainPanel/index.tsx`](diffhunk://#diff-052f6fad922589a095f3b28a0f53487a0ba29deb4dd0232fb04ac49ce98883b4R264): Added a line to set `newNode` to `null` after adding a new node.
* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L108-R108): Updated the window creation parameters to set a minimum size instead of fixed width and height.
* [`server/services/core/mapping_to_yarrrml_service.py`](diffhunk://#diff-5138d26e7b79f834ab4a26781f6e9c7aa5cef326d2591a5183c11da8b800c34cR114-R116): Added a check to ensure the JSON path iterator ends with `.[*]` for JSON sources.