### PR TITLE
Fix the mapping error on Linux machines that uses docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,8 @@ FROM ghcr.io/astral-sh/uv:python3.11-alpine
 
 # Install JRE and curl
 
-RUN apk add --no-cache openjdk11-jre && \
+RUN apk add --no-cache openjdk17-jdk && \
     addgroup -S app && adduser -S app -G app
-
-USER app
 
 ENV DEBUG=1
 
@@ -30,6 +28,9 @@ WORKDIR /app
 # Download RMLMapper
 
 ADD https://github.com/RMLio/rmlmapper-java/releases/download/v7.2.0/rmlmapper-7.2.0-r374-all.jar ./bin/mapper.jar
+
+# Modify the permissions of RMLMapper
+RUN chmod 755 bin/mapper.jar
 
 # Copy the backend dependencies
 


### PR DESCRIPTION
## Error description

The error was discovered on Linux when using docker. When clicking on the map button a 500 error was displayed on the UI and the error was: *mapper.jar file not accessible*.

## Fix description

- removing the app user
- replacing the installation of the openjdk11 alpine package to a latest version (openjdk-17)
- opening the permission of the bin/mapper.jar file

## Warnings

These changes work on Linux Ubuntu and should work on all other systems that use docker for the application.
However, further tests should be done to check if the deleted app user hurt certain features of the app. 

### Contacts

Brieuc Quemeneur
brieuc.quemeneur@univ-nantes.fr